### PR TITLE
print statistics to stderr instead of stdout

### DIFF
--- a/minimize_net_list.py
+++ b/minimize_net_list.py
@@ -46,5 +46,5 @@ Root.collapseRoot(Root.real_ip_records_count - required_list_size)
 Root.printCollapsedTree();
 
 # printing some stats
-print('### list size:    ' + str(Root.real_ip_records_count))
-print('### not real ips: ' + str(Root.added_fake_ip_volume))
+print('### list size:    ' + str(Root.real_ip_records_count), file=sys.stderr)
+print('### not real ips: ' + str(Root.added_fake_ip_volume), file=sys.stderr)


### PR DESCRIPTION
Это позволит избежать необходимости в последующей фильтрации выходного списка через grep -v.