### PR TITLE
Collapse on add

### DIFF
--- a/net_tree.py
+++ b/net_tree.py
@@ -83,21 +83,27 @@ class Node:
 
         if self.is_real_net:
             return 1
+        
+        # C1 is filled in first, then C2. Therefore, if there is no C1, then there is no C2.
+        if not self.child1:
+            self.child1 = NewNode
 
-        for Child in (self.child1, self.child2):
-            if Child and Child.addSubnet(NewNode):
-                self.collapseRealChilds()
-                return 1
+        if self.child1.addSubnet(NewNode):
+            self.collapseRealChilds()
+            return 1
+        
+        if self.child2 and self.child2.addSubnet(NewNode):
+            self.collapseRealChilds()
+            return 1
 
-        if self.child1:
-            CommonNet = self.child1.net.getCommonNet(NewNode.net, self.net.mask_size + 1)
-            if CommonNet:
-                CommonNode = Node(CommonNet, 0)
-                CommonNode.addSubnet(NewNode)
-                CommonNode.addSubnet(self.child1)
-                self.child1 = CommonNode
-                self.collapseRealChilds()
-                return 1
+        CommonNet = self.child1.net.getCommonNet(NewNode.net, self.net.mask_size + 1)
+        if CommonNet:
+            CommonNode = Node(CommonNet, 0)
+            CommonNode.addSubnet(NewNode)
+            CommonNode.addSubnet(self.child1)
+            self.child1 = CommonNode
+            self.collapseRealChilds()
+            return 1
 
         if self.child2:
             CommonNet = self.child2.net.getCommonNet(NewNode.net, self.net.mask_size + 1)
@@ -109,12 +115,8 @@ class Node:
                 self.collapseRealChilds()
                 return 1
 
-        if not self.child1:
-            self.child1 = NewNode
-        else:
-            self.child2 = NewNode
-            self.collapseRealChilds()
-
+        self.child2 = NewNode
+        self.collapseRealChilds()
         return 1
 
     def printTree(self, level):

--- a/net_tree.py
+++ b/net_tree.py
@@ -87,6 +87,7 @@ class Node:
         # C1 is filled in first, then C2. Therefore, if there is no C1, then there is no C2.
         if not self.child1:
             self.child1 = NewNode
+            return 1
 
         if self.child1.addSubnet(NewNode):
             self.collapseRealChilds()

--- a/net_tree.py
+++ b/net_tree.py
@@ -78,11 +78,11 @@ class Node:
                 self.child2 = None
             return 1
 
-        if self.is_real_net and self.net.hasSubnet(NewNode.net):
-            return 1
-
         if not self.net.hasSubnet(NewNode.net):
             return 0
+
+        if self.is_real_net:
+            return 1
 
         for Child in (self.child1, self.child2):
             if Child and Child.addSubnet(NewNode):

--- a/net_tree.py
+++ b/net_tree.py
@@ -60,6 +60,15 @@ class Node:
 
     def getNet(self):
         return self.net
+    
+    def collapseRealChilds(self):
+        if self.child1 and self.child2 and self.child1.is_real_net and self.child2.is_real_net:
+            c1_mask_size = self.child1.net.mask_size
+            if c1_mask_size == self.child2.net.mask_size and (c1_mask_size == (self.net.mask_size + 1)):
+                self.is_real_net = 1
+                self.child1 = None
+                self.child2 = None
+        return
 
     def addSubnet(self, NewNode: 'Node'):
         if self.net.isSameNet(NewNode.net):
@@ -77,6 +86,7 @@ class Node:
 
         for Child in (self.child1, self.child2):
             if Child and Child.addSubnet(NewNode):
+                self.collapseRealChilds()
                 return 1
 
         if self.child1:
@@ -86,6 +96,7 @@ class Node:
                 CommonNode.addSubnet(NewNode)
                 CommonNode.addSubnet(self.child1)
                 self.child1 = CommonNode
+                self.collapseRealChilds()
                 return 1
 
         if self.child2:
@@ -95,12 +106,14 @@ class Node:
                 CommonNode.addSubnet(NewNode)
                 CommonNode.addSubnet(self.child2)
                 self.child2 = CommonNode
+                self.collapseRealChilds()
                 return 1
 
         if not self.child1:
             self.child1 = NewNode
         else:
             self.child2 = NewNode
+            self.collapseRealChilds()
 
         return 1
 

--- a/net_tree.py
+++ b/net_tree.py
@@ -61,7 +61,7 @@ class Node:
     def getNet(self):
         return self.net
     
-    def collapseRealChilds(self):
+    def collapseRealChildren(self):
         if self.child1 and self.child2 and self.child1.is_real_net and self.child2.is_real_net:
             c1_mask_size = self.child1.net.mask_size
             if c1_mask_size == self.child2.net.mask_size and (c1_mask_size == (self.net.mask_size + 1)):
@@ -90,11 +90,11 @@ class Node:
             return 1
 
         if self.child1.addSubnet(NewNode):
-            self.collapseRealChilds()
+            self.collapseRealChildren()
             return 1
         
         if self.child2 and self.child2.addSubnet(NewNode):
-            self.collapseRealChilds()
+            self.collapseRealChildren()
             return 1
 
         CommonNet = self.child1.net.getCommonNet(NewNode.net, self.net.mask_size + 1)
@@ -103,7 +103,7 @@ class Node:
             CommonNode.addSubnet(NewNode)
             CommonNode.addSubnet(self.child1)
             self.child1 = CommonNode
-            self.collapseRealChilds()
+            self.collapseRealChildren()
             return 1
 
         if self.child2:
@@ -113,11 +113,11 @@ class Node:
                 CommonNode.addSubnet(NewNode)
                 CommonNode.addSubnet(self.child2)
                 self.child2 = CommonNode
-                self.collapseRealChilds()
+                self.collapseRealChildren()
                 return 1
 
         self.child2 = NewNode
-        self.collapseRealChilds()
+        self.collapseRealChildren()
         return 1
 
     def printTree(self, level):


### PR DESCRIPTION
У меня списки адресов не настолько огромны как в примере (~100-150), поэтому мне нужно лишь избавиться от дублей и объединить соседние адреса. С дублями понятно, а вот с соседями приходилось подбирать требуемый размер списка.

Добавил дополнительные проверки в Node.addSubnet(). Нужного эффекта добился, но ожидаемо увеличилось время работы. Для компенсации немного оптимизировал функцию добавления, а именно:

1. Изменил порядок проверки self.net.hasSubnet(NewNode.net), чтобы убрать повторную проверку.
2. Перенёс повыше проверку на существование child1 (поскольку они заполняются по порядку, то справедливо предположить, что если нет С1, то нет и С2). Развернул цикл for и убрал последующие проверки на существование child1.

После оптимизации формирование дерева на тестовом примере стало происходить быстрее изначального.

Если нужно ещё больше скорости, то предварительное объединение соседей можно убрать в отдельную функцию (и использовать её вместо Root.collapseRoot() если параметр N<1) или переместить в finishTreeFirst().